### PR TITLE
feat: integrate OpenAI image generation with safe fallbacks

### DIFF
--- a/core/core_engine.py
+++ b/core/core_engine.py
@@ -46,8 +46,7 @@ def _ensure_tools_available() -> List[str]:
 def quick_diagnose() -> Dict:
     return {
         "images_dir_exists": IMAGES_DIR.exists(),
-        "images_count": len(list(IMAGES_DIR.glob("*.png")))
-        + len(list(IMAGES_DIR.glob("*.jpg"))),
+        "images_count": len(list(IMAGES_DIR.glob("*.png"))),
         "voice_exists": VOICE_PATH.exists(),
         "voice_size": VOICE_PATH.stat().st_size if VOICE_PATH.exists() else 0,
         "final_videos_dir_exists": FINAL_VIDS_DIR.exists(),


### PR DESCRIPTION
## Summary
- use OpenAI image API when available and fall back to local placeholder images when unavailable
- wire image generation flag through engine and Streamlit UI
- simplify diagnose helper to count only generated PNG images

## Testing
- `python - <<'PY'
from core.core_engine import run_full_generation, quick_diagnose
script = 'Scene 1: Hello\n\nScene 2: Bye\n'
res = run_full_generation(user_data={'topic':'test','traits':{'tone':'neutral'}}, lang='en', image_duration=1, override_script=script, mute_if_no_voice=True, skip_cleanup=False, use_ai_flag=False)
print('result', res)
print('diagnose', quick_diagnose())
PY`
- `python - <<'PY'
from core.core_engine import quick_diagnose
print(quick_diagnose())
PY`


------
https://chatgpt.com/codex/tasks/task_e_689cff1ed6c0832182279ef4bcbdf6c1