### PR TITLE
Add stock photo generation with safe fallbacks

### DIFF
--- a/app_streamlit.py
+++ b/app_streamlit.py
@@ -23,7 +23,8 @@ Outro: Give it 10 minutes today.
 script = st.text_area("Script", value=DEFAULT_SCRIPT, height=220)
 secs = st.slider("Seconds per image", 2, 8, 4, 1)
 add_voice = st.checkbox("Add voice-over", value=False)
-use_ai = st.checkbox("Use AI images (OpenAI)", value=True)
+use_ai = st.checkbox("Use AI images (OpenAI)", value=False)
+use_stock = st.checkbox("Use stock photos (free)", value=True)
 show_debug = st.checkbox("Show debug (diagnose)", value=True)
 
 col1, col2 = st.columns(2)
@@ -39,7 +40,8 @@ with col1:
                     override_script=script,
                     mute_if_no_voice=not add_voice,
                     skip_cleanup=False,   # ننظّف صور قديمة قبل كل تشغيل
-                    use_ai_flag=use_ai,
+                    use_stock_flag=use_stock,
+                    use_openai_flag=use_ai,
                 )
 
             if res.get("error"):

--- a/render.yaml
+++ b/render.yaml
@@ -9,3 +9,9 @@ services:
     envVars:
       - key: PYTHON_VERSION
         value: 3.11.9
+      - key: PEXELS_API_KEY
+        value: ""
+      - key: UNSPLASH_ACCESS_KEY
+        value: ""
+      - key: PIXABAY_API_KEY
+        value: ""

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 --prefer-binary
 streamlit==1.35.0
-requests>=2.31.0
+requests>=2.31.0  # for stock image APIs
 moviepy==1.0.3
 Pillow>=10.0.0
 imageio>=2.9.0

--- a/smoke_stock_images.py
+++ b/smoke_stock_images.py
@@ -1,0 +1,16 @@
+#!/usr/bin/env python3
+"""Simple smoke test for stock image fetching."""
+from pathlib import Path
+from content_studio.ai_images.generate_images import generate_images
+
+SCRIPT = (
+    "Scene 1: A bright stadium\n\n"
+    "Scene 2: A cheering crowd\n\n"
+    "Scene 3: A trophy lift"
+)
+
+if __name__ == "__main__":
+    paths = generate_images(SCRIPT, "en", use_stock=True, use_openai=False)
+    print(paths)
+    existing = [p for p in paths if Path(p).exists()]
+    raise SystemExit(0 if existing else 1)


### PR DESCRIPTION
## Summary
- Expand `generate_images` to optionally fetch free stock photos from Pexels, Unsplash, Pixabay, Unsplash Source or local placeholders
- Wire new stock/OpenAI flags through core engine and Streamlit UI with explicit provider logging
- Declare stock photo API keys in `render.yaml` and add smoke test for image fetching

## Testing
- `python smoke_stock_images.py`


------
https://chatgpt.com/codex/tasks/task_e_689d9027a4f08321ad5768c462122e5b