### PR TITLE
fix: ensure join inputs are strings

### DIFF
--- a/agents/marketing/emotional_flow_model.py
+++ b/agents/marketing/emotional_flow_model.py
@@ -20,7 +20,7 @@ def apply_emotional_structure(story_prompt: dict) -> list:
         f"{hook}\n\n{get_transition(0)}\nWe often go through life accepting certain truths without question.\nBut sometimes… all it takes is one new idea to shatter the illusion.",
 
         # 2. Inner Friction
-        f"{get_transition(1)}\nMany of us feel disconnected — not because we're lazy, but because something in our environment misaligned with us.\nDrivers like {', '.join(drivers)} are often misunderstood — or ignored completely.",
+        f"{get_transition(1)}\nMany of us feel disconnected — not because we're lazy, but because something in our environment misaligned with us.\nDrivers like {', '.join(str(x) for x in drivers)} are often misunderstood — or ignored completely.",
 
         # 3. Collapse Moment
         f"{get_transition(2)}\nWhat if the problem wasn’t you?\nWhat if the system — the culture, the expectations — was never built with someone like you in mind?\nThat realization can feel like collapse — but it’s actually clarity.",

--- a/analysis/layer_z_engine.py
+++ b/analysis/layer_z_engine.py
@@ -71,7 +71,7 @@ def _quick_fallback_from_text(answers: Dict[str, Any], lang: str) -> List[str]:
             else: joined.append(str(a))
         else:
             joined.append(str(v))
-    text = "\n".join(joined).lower()
+    text = "\n".join(str(x) for x in joined).lower()
     ar = (lang == "العربية")
 
     out: List[str] = []

--- a/analysis/user_analysis.py
+++ b/analysis/user_analysis.py
@@ -32,7 +32,7 @@ def _answers_to_text(answers: Dict[str, Any]) -> str:
                 parts.append(str(a))
         else:
             parts.append(str(v))
-    return " ".join(parts)
+    return " ".join(str(x) for x in parts)
 
 def _try_encode_profile(answers: Dict[str, Any], lang: str) -> Dict[str, Any]:
     # 1) لو فيه بروفايل مرسَّل جاهز
@@ -84,7 +84,7 @@ def apply_all_analysis_layers(text_or_answers: Union[str, Dict[str, Any]], lang:
         z_drivers = [f"Layer-Z error: {e}"]
 
     # ملخّص سريع قابل للعرض
-    quick_profile = " | ".join([t for t in traits if isinstance(t, str)])[:240]
+    quick_profile = " | ".join(str(t) for t in traits if isinstance(t, str))[:240]
 
     # بروفايل مُشفَّر (إن توفر)
     encoded = _try_encode_profile(answers, lang) if answers else {}

--- a/content_studio/ai_images/generate_images.py
+++ b/content_studio/ai_images/generate_images.py
@@ -30,10 +30,10 @@ def _split_scenes(script: str) -> List[str]:
     buf = []
     for line in parts:
         if line.lower().startswith(("scene","مشهد","outro","title")) and buf:
-            scenes.append(" ".join(buf)); buf=[line]
+            scenes.append(" ".join(str(x) for x in buf)); buf=[line]
         else:
             buf.append(line)
-    if buf: scenes.append(" ".join(buf))
+    if buf: scenes.append(" ".join(str(x) for x in buf))
     return scenes[:4] if scenes else [script.strip()[:140]]
 
 def _try_openai(prompt: str) -> bytes | None:

--- a/content_studio/content_engine.py
+++ b/content_studio/content_engine.py
@@ -27,7 +27,7 @@ def suggest_topic_from_keywords(keywords: list) -> str:
     """
     🧠 بناء موضوع ذكي تلقائي من قائمة مفاتيح (hooks أو سمات)
     """
-    base = ", ".join(keywords)
+    base = ", ".join(str(x) for x in keywords)
     return f"How {base} influences your sport identity"
 
 

--- a/content_studio/publishing_engine.py
+++ b/content_studio/publishing_engine.py
@@ -99,7 +99,7 @@ def export_video_package(script_text, index=1):
     (folder / "long_script.txt").write_text(script_text, encoding="utf-8")
     (folder / "title.txt").write_text(title, encoding="utf-8")
     (folder / "description.txt").write_text(desc, encoding="utf-8")
-    (folder / "tags.txt").write_text(", ".join(tags), encoding="utf-8")
+    (folder / "tags.txt").write_text(", ".join(str(x) for x in tags), encoding="utf-8")
     (folder / "thumbnail_text.txt").write_text(thumbnail_text, encoding="utf-8")
 
     # Shorts

--- a/core/answers_encoder.py
+++ b/core/answers_encoder.py
@@ -132,7 +132,7 @@ def _extract_all_text(answers: Dict[str, Any]) -> str:
                 parts.append(str(ans))
         else:
             parts.append(str(v))
-    return "\n".join(parts)
+    return "\n".join(str(x) for x in parts)
 
 def _clamp(v: float, lo: float, hi: float) -> float:
     return max(lo, min(hi, v))

--- a/core/backend_gpt.py
+++ b/core/backend_gpt.py
@@ -202,7 +202,7 @@ def _as_text(v: Any) -> str:
     if isinstance(v, str):
         return v
     if isinstance(v, list):
-        return "، ".join(_as_text(x) for x in v if _as_text(x))
+        return "، ".join(str(_as_text(x)) for x in v if _as_text(x))
     if isinstance(v, (int, float)):
         return str(v)
     try:
@@ -250,7 +250,7 @@ def _extract_signals(answers: Dict[str, Any], lang: str) -> Dict[str, int]:
     باستخدام z_intent_keywords إن توفّرت.
     """
     blob = " ".join(
-        (v.get("answer") if isinstance(v, dict) and "answer" in v else str(v))
+        str(v.get("answer") if isinstance(v, dict) and "answer" in v else v)
         for v in (answers or {}).values()
     )
     blob_l = blob.lower()
@@ -316,7 +316,7 @@ def _extract_profile(answers: Dict[str, Any], lang: str) -> Optional[Dict[str, A
         preferences = enc.get("prefs", enc.get("preferences", {}))
         z_markers = enc.get("z_markers", [])
         signals   = enc.get("signals", [])
-        hints = " | ".join([*z_markers, *signals])[:1000]
+        hints = " | ".join(str(x) for x in [*z_markers, *signals])[:1000]
         return {
             "scores": enc.get("scores", {}),
             "axes": enc.get("axes", {}),
@@ -399,7 +399,7 @@ def _format_followup_card(followups: List[str], lang: str) -> str:
     lines.append("")
     lines.append("أرسل إجاباتك وسنقترح هوية رياضية واضحة فورًا." if lang == "العربية"
                  else "Send your answers and I’ll propose a clear sport-identity right away.")
-    return "\n".join(lines)
+    return "\n".join(str(x) for x in lines)
 
 # ========= Rules & helpers =========
 _BLOCKLIST = r"(جري|ركض|سباحة|كرة|قدم|سلة|طائرة|تنس|ملاكمة|كاراتيه|كونغ فو|يوجا|يوغا|بيلاتس|رفع|أثقال|تزلج|دراج|دراجة|ركوب|خيول|باركور|جودو|سكواش|بلياردو|جولف|كرة طائرة|كرة اليد|هوكي|سباق|ماراثون|مصارعة|MMA|Boxing|Karate|Judo|Taekwondo|Soccer|Football|Basketball|Tennis|Swim|Swimming|Running|Run|Cycle|Cycling|Bike|Biking|Yoga|Pilates|Rowing|Row|Skate|Skating|Ski|Skiing|Climb|Climbing|Surf|Surfing|Golf|Volleyball|Handball|Hockey|Parkour|Wrestling)"
@@ -448,7 +448,7 @@ def _split_sentences(text: str) -> List[str]:
 
 def _scrub_forbidden(text: str) -> str:
     kept = [s for s in _split_sentences(text) if not _FORBIDDEN_SENT.search(_normalize_ar(s))]
-    return "، ".join(kept).strip(" .،")
+    return "، ".join(str(x) for x in kept).strip(" .،")
 
 def _clip(s: str, n: int) -> str:
     if not s: return ""
@@ -467,7 +467,7 @@ def _answers_to_bullets(answers: Dict[str, Any]) -> str:
         if isinstance(a, list):
             a = ", ".join(map(str, a))
         out.append(f"- {q}: {_clip(str(a), 160)}")
-    txt = "\n".join(out)
+    txt = "\n".join(str(x) for x in out)
     return _clip(txt, 1800)
 
 def _too_generic(text: str, min_chars: int = 280) -> bool:
@@ -478,7 +478,7 @@ def _has_sensory(text: str, min_hits: int = 3) -> bool:
     return sum(1 for w in _SENSORY if w in (text or "")) >= min_hits
 
 def _is_meaningful(rec: Dict[str, Any]) -> bool:
-    blob = " ".join([
+    blob = " ".join(str(x) for x in [
         _as_text(rec.get("sport_label","")), _as_text(rec.get("what_it_looks_like","")),
         _as_text(rec.get("why_you","")), _as_text(rec.get("first_week","")),
         _as_text(rec.get("progress_markers","")), _as_text(rec.get("win_condition",""))
@@ -521,7 +521,7 @@ def _axes_expectations(axes: Dict[str, float], lang: str) -> Dict[str, List[str]
 def _mismatch_with_axes(rec: Dict[str, Any], axes: Dict[str, float], lang: str) -> bool:
     exp = _axes_expectations(axes or {}, lang)
     if not exp: return False
-    blob = " ".join(_as_text(rec.get(k,"")) for k in ("what_it_looks_like","inner_sensation","why_you","first_week"))
+    blob = " ".join(str(_as_text(rec.get(k,""))) for k in ("what_it_looks_like","inner_sensation","why_you","first_week"))
     blob_l = blob.lower()
     for _, words in exp.items():
         if words and not any(w.lower() in blob_l for w in words):
@@ -547,7 +547,7 @@ def _tokenize(text: str) -> List[str]:
 
 def _sig_for_rec(r: Dict[str, Any]) -> set:
     core = r.get("core_skills") or []
-    core_txt = " ".join(core) if isinstance(core, list) else str(core)
+    core_txt = " ".join(str(x) for x in core) if isinstance(core, list) else str(core)
     toks = set(_tokenize(r.get("sport_label","")) + _tokenize(core_txt))
     return toks
 
@@ -809,7 +809,7 @@ def _derive_binary_traits(analysis: Dict[str, Any], answers: Dict[str, Any], lan
         traits["sustained_attention"] = max(traits.get("sustained_attention", 0.0), 0.6)
 
     # قلق/نفور من التكرار/حاجة مكاسب سريعة
-    ar_blob = _normalize_ar(" ".join(_norm_answer_value(v) for v in (answers or {}).values()).lower())
+    ar_blob = _normalize_ar(" ".join(str(_norm_answer_value(v)) for v in (answers or {}).values()).lower())
     if any(w in ar_blob for w in ["قلق","مخاوف","توتر شديد","رهاب","خوف"]):
         traits["anxious"] = 1.0
     if any("نفور" in s or "تكرار" in s for s in silent):
@@ -853,7 +853,7 @@ def _pick_kb_recommendations(user_axes: Dict[str, Any], user_signals: Dict[str, 
     exp = _axes_expectations(user_axes or {}, lang)
     for rec in identities:
         r = _sanitize_record(rec)
-        blob = " ".join([_as_text(r.get("what_it_looks_like","")), _as_text(r.get("why_you","")), _as_text(r.get("first_week",""))]).lower()
+        blob = " ".join(str(x) for x in [_as_text(r.get("what_it_looks_like","")), _as_text(r.get("why_you","")), _as_text(r.get("first_week",""))]).lower()
         hit = 0
         for words in exp.values():
             if words and any(w.lower() in blob for w in words):
@@ -1189,11 +1189,11 @@ def _json_prompt(analysis: Dict[str, Any], answers: Dict[str, Any],
                 {"calm_adrenaline":"Calm/Adrenaline","solo_group":"Solo/Group","tech_intuition":"Technical/Intuitive"}
         for k, words in exp.items():
             if words:
-                exp_lines.append(f"{title[k]}: {', '.join(words)}")
-    axis_hint = ("\n".join(exp_lines)) if exp_lines else ""
+                exp_lines.append(f"{title[k]}: {', '.join(str(x) for x in words)}")
+    axis_hint = ("\n".join(str(x) for x in exp_lines)) if exp_lines else ""
 
     z_intent = compact_analysis.get("z_intent", [])
-    intent_hint = ("، ".join(z_intent) if lang=="العربية" else ", ".join(z_intent)) if z_intent else ""
+    intent_hint = ("، ".join(str(x) for x in z_intent) if lang=="العربية" else ", ".join(str(x) for x in z_intent)) if z_intent else ""
 
     if lang == "العربية":
         sys = (
@@ -1272,7 +1272,7 @@ def _to_bullets(text: Any, max_items: int = 6) -> List[str]:
     return items[:max_items]
 
 def _one_liner(*parts: str, max_len: int = 140) -> str:
-    s = " — ".join([p.strip() for p in parts if p and p.strip()])
+    s = " — ".join(str(p).strip() for p in parts if p and str(p).strip())
     return s[:max_len]
 
 def _format_card(rec: Dict[str, Any], i: int, lang: str) -> str:
@@ -1317,9 +1317,9 @@ def _format_card(rec: Dict[str, Any], i: int, lang: str) -> str:
         if novr: notes.append("بدون VR: " + novr)
         if vr: notes.append("VR (اختياري): " + vr)
         if notes:
-            out += ["\n👁‍🗨 ملاحظات:", f"- " + "\n- ".join(notes)]
+            out += ["\n👁‍🗨 ملاحظات:", f"- " + "\n- ".join(str(x) for x in notes)]
         out.append(f"\nالمستوى التقريبي: {diff}/5")
-        return "\n".join(out)
+        return "\n".join(str(x) for x in out)
     else:
         out = [head, ""]
         if label: out.append(f"🎯 Ideal identity: {label}")
@@ -1342,16 +1342,16 @@ def _format_card(rec: Dict[str, Any], i: int, lang: str) -> str:
         if novr: notes.append("No-VR: " + novr)
         if vr: notes.append("VR (optional): " + vr)
         if notes:
-            out += ["\n👁‍🗨 Notes:", f"- " + "\n- ".join(notes)]
+            out += ["\n👁‍🗨 Notes:", f"- " + "\n- ".join(str(x) for x in notes)]
         out.append(f"\nApprox level: {diff}/5")
-        return "\n".join(out)
+        return "\n".join(str(x) for x in out)
 
 def _sanitize_fill(recs: List[Dict[str, Any]], lang: str) -> List[Dict[str, Any]]:
     temp: List[Dict[str, Any]] = []
     for i in range(3):
         r = recs[i] if i < len(recs) else {}
         r = _fill_defaults(_sanitize_record(r), lang)
-        blob = " ".join([
+        blob = " ".join(str(x) for x in [
             _as_text(r.get("sport_label","")), _as_text(r.get("what_it_looks_like","")),
             _as_text(r.get("why_you","")), _as_text(r.get("first_week","")),
             _as_text(r.get("progress_markers","")), _as_text(r.get("win_condition",""))
@@ -1570,7 +1570,7 @@ def generate_sport_recommendation(answers: Dict[str, Any],
     axes = (analysis.get("z_axes") or {}) if isinstance(analysis, dict) else {}
 
     mismatch_axes = any(_mismatch_with_axes(rec, axes, lang) for rec in cleaned)
-    need_repair_generic = any(_too_generic(" ".join([_as_text(c.get("what_it_looks_like","")), _as_text(c.get("why_you",""))]), _MIN_CHARS) for c in cleaned)
+    need_repair_generic = any(_too_generic(" ".join(str(x) for x in [_as_text(c.get("what_it_looks_like","")), _as_text(c.get("why_you",""))]), _MIN_CHARS) for c in cleaned)
     missing_fields = any(((_REQUIRE_WIN and not c.get("win_condition")) or len(c.get("core_skills") or []) < _MIN_CORE_SKILLS) for c in cleaned)
     need_repair = (mismatch_axes or need_repair_generic or missing_fields) and REC_REPAIR_ENABLED and (time_left >= (6 if not REC_FAST_MODE else 4))
 
@@ -1581,16 +1581,16 @@ def generate_sport_recommendation(answers: Dict[str, Any],
             if lang == "العربية":
                 align_hint = (
                     "حاذِ التوصيات مع محاور Z:\n"
-                    f"- هدوء/أدرينالين: {', '.join(exp.get('calm_adrenaline', []))}\n"
-                    f"- فردي/جماعي: {', '.join(exp.get('solo_group', []))}\n"
-                    f"- تقني/حدسي: {', '.join(exp.get('tech_intuition', []))}\n"
+                    f"- هدوء/أدرينالين: {', '.join(str(x) for x in exp.get('calm_adrenaline', []))}\n"
+                    f"- فردي/جماعي: {', '.join(str(x) for x in exp.get('solo_group', []))}\n"
+                    f"- تقني/حدسي: {', '.join(str(x) for x in exp.get('tech_intuition', []))}\n"
                 )
             else:
                 align_hint = (
                     "Align with Z-axes:\n"
-                    f"- Calm/Adrenaline: {', '.join(exp.get('calm_adrenaline', []))}\n"
-                    f"- Solo/Group: {', '.join(exp.get('solo_group', []))}\n"
-                    f"- Technical/Intuitive: {', '.join(exp.get('tech_intuition', []))}\n"
+                    f"- Calm/Adrenaline: {', '.join(str(x) for x in exp.get('calm_adrenaline', []))}\n"
+                    f"- Solo/Group: {', '.join(str(x) for x in exp.get('solo_group', []))}\n"
+                    f"- Technical/Intuitive: {', '.join(str(x) for x in exp.get('tech_intuition', []))}\n"
                 )
         repair_prompt = {
             "role":"user",
@@ -1614,7 +1614,7 @@ def generate_sport_recommendation(answers: Dict[str, Any],
             cleaned2 = _sanitize_fill(parsed2, lang)
 
             def score(r: Dict[str,Any]) -> int:
-                txt = " ".join([
+                txt = " ".join(str(x) for x in [
                     _as_text(r.get("sport_label","")), _as_text(r.get("what_it_looks_like","")),
                     _as_text(r.get("inner_sensation","")), _as_text(r.get("why_you","")),
                     _as_text(r.get("first_week","")), _as_text(r.get("win_condition",""))
@@ -1643,8 +1643,8 @@ def generate_sport_recommendation(answers: Dict[str, Any],
 
     axes = (analysis.get("z_axes") or {}) if isinstance(analysis, dict) else {}
     quality_flags = {
-        "generic": any(_too_generic(" ".join([_as_text(c.get("what_it_looks_like","")), _as_text(c.get("why_you",""))]), _MIN_CHARS) for c in cleaned),
-        "low_sensory": any(not _has_sensory(" ".join([_as_text(c.get("what_it_looks_like","")), _as_text(c.get("inner_sensation",""))])) for c in cleaned),
+        "generic": any(_too_generic(" ".join(str(x) for x in [_as_text(c.get("what_it_looks_like","")), _as_text(c.get("why_you",""))]), _MIN_CHARS) for c in cleaned),
+        "low_sensory": any(not _has_sensory(" ".join(str(x) for x in [_as_text(c.get("what_it_looks_like","")), _as_text(c.get("inner_sensation",""))])) for c in cleaned),
         "mismatch_axes": any(_mismatch_with_axes(c, axes, lang) for c in cleaned),
         "missing_fields": any(((_REQUIRE_WIN and not c.get("win_condition")) or len(c.get("core_skills") or []) < _MIN_CORE_SKILLS) for c in cleaned)
     }

--- a/core/dynamic_chat.py
+++ b/core/dynamic_chat.py
@@ -192,15 +192,15 @@ def _profile_brief(profile: Dict[str, Any], lang: str) -> str:
     if lang == "العربية":
         return (
             "ملخص بروفايل مرمّز:\n"
-            f"- إشارات: {', '.join(signals) if signals else 'n/a'}\n"
-            f"- أعلى الدرجات: {', '.join(top_scores) if top_scores else 'n/a'}\n"
+            f"- إشارات: {', '.join(str(x) for x in signals) if signals else 'n/a'}\n"
+            f"- أعلى الدرجات: {', '.join(str(x) for x in top_scores) if top_scores else 'n/a'}\n"
             f"- تفضيلات: وقت={prefs.get('time_block','n/a')}, ميزانية={prefs.get('budget_hint','n/a')}, بيئة={prefs.get('environment_pref','n/a')}\n"
         )
     else:
         return (
             "Encoded profile brief:\n"
-            f"- Signals: {', '.join(signals) if signals else 'n/a'}\n"
-            f"- Top scores: {', '.join(top_scores) if top_scores else 'n/a'}\n"
+            f"- Signals: {', '.join(str(x) for x in signals) if signals else 'n/a'}\n"
+            f"- Top scores: {', '.join(str(x) for x in top_scores) if top_scores else 'n/a'}\n"
             f"- Prefs: time={prefs.get('time_block','n/a')}, budget={prefs.get('budget_hint','n/a')}, env={prefs.get('environment_pref','n/a')}\n"
         )
 
@@ -277,9 +277,9 @@ def start_dynamic_chat(
         # 7.1) ملخص طبقة Z + البروفايل المرمّز (system قصير)
         brief_lines = []
         if z:
-            brief_lines.append(("محركات Z: " if lang == "العربية" else "Layer-Z: ") + ", ".join(z))
+            brief_lines.append(("محركات Z: " if lang == "العربية" else "Layer-Z: ") + ", ".join(str(x) for x in z))
         brief_lines.append(_profile_brief(encoded, lang))
-        messages.append({"role": "system", "content": "\n".join(brief_lines)})
+        messages.append({"role": "system", "content": "\n".join(str(x) for x in brief_lines)})
 
         # 7.2) سياق مختصر حول التوصيات والتقييمات + Z-axes/Z-markers
         if previous_recommendation:
@@ -296,7 +296,7 @@ def start_dynamic_chat(
         try:
             brief_context += (
                 f"- Z-axes: {json.dumps(encoded.get('axes', {}), ensure_ascii=False)}\n"
-                f"- Z-markers: {', '.join(encoded.get('z_markers', []))}\n"
+                f"- Z-markers: {', '.join(str(x) for x in encoded.get('z_markers', []))}\n"
             )
         except Exception:
             pass
@@ -441,9 +441,9 @@ def start_dynamic_chat_stream(
     messages: List[Dict[str, str]] = [{"role": "system", "content": system_prompt}]
     brief = []
     if z:
-        brief.append(("محركات Z: " if lang=="العربية" else "Layer-Z: ") + ", ".join(z))
+        brief.append(("محركات Z: " if lang=="العربية" else "Layer-Z: ") + ", ".join(str(x) for x in z))
     brief.append(_profile_brief(encoded, lang))
-    messages.append({"role": "system", "content": "\n".join(brief)})
+    messages.append({"role": "system", "content": "\n".join(str(x) for x in brief)})
 
     if previous_recommendation:
         rec_join = "\n- " + "\n- ".join(map(str, previous_recommendation[:3]))
@@ -459,7 +459,7 @@ def start_dynamic_chat_stream(
     try:
         brief_context += (
             f"- Z-axes: {json.dumps(encoded.get('axes', {}), ensure_ascii=False)}\n"
-            f"- Z-markers: {', '.join(encoded.get('z_markers', []))}\n"
+            f"- Z-markers: {', '.join(str(x) for x in encoded.get('z_markers', []))}\n"
         )
     except Exception:
         pass
@@ -502,7 +502,7 @@ def start_dynamic_chat_stream(
                 yield part
     finally:
         # تسجيل التفاعل بعد اكتمال البث
-        reply_full = "".join(final_buf).strip()
+        reply_full = "".join(str(x) for x in final_buf).strip()
         payload_log = {
             "language": lang,
             "answers": answers,

--- a/core/followup_questions.py
+++ b/core/followup_questions.py
@@ -26,7 +26,7 @@ def start_dynamic_followup_chat(user_message, user_id, previous_recommendation, 
 نبرتك: {personality['tone']}
 أسلوبك: {personality['style']}
 فلسفتك: {personality['philosophy']}
-السمات المستخرجة: {', '.join(all_traits)}
+السمات المستخرجة: {', '.join(str(x) for x in all_traits)}
 
 مهمتك: التفاعل مع المستخدم بذكاء.
 ❌ لا تكرر التوصية السابقة.
@@ -44,7 +44,7 @@ You are {personality['name']}, a smart coach working within the Sport Sync syste
 Tone: {personality['tone']}
 Style: {personality['style']}
 Philosophy: {personality['philosophy']}
-User traits: {', '.join(all_traits)}
+User traits: {', '.join(str(x) for x in all_traits)}
 
 Your task is to respond intelligently to the user.
 ❌ Do not repeat the previous recommendation.

--- a/core/kb_ranker.py
+++ b/core/kb_ranker.py
@@ -69,7 +69,7 @@ def _blob_from_answers(answers: Dict[str, Any]) -> str:
             parts.append(", ".join(map(str, v)))
         else:
             parts.append(str(v))
-    return " ".join(parts)
+    return " ".join(str(x) for x in parts)
 
 KW = {
     "ar": {
@@ -204,7 +204,7 @@ def load_identity(label: str, lang: str, identities_dir: Path, kb: dict) -> Dict
     return out
 
 def _one_liner(*parts: str, max_len: int = 140) -> str:
-    s = " — ".join([p.strip() for p in parts if p and str(p).strip()])
+    s = " — ".join(str(p).strip() for p in parts if p and str(p).strip())
     return s[:max_len]
 
 def _bullets(text: str, max_items: int = 6) -> List[str]:
@@ -249,9 +249,9 @@ def render_card(rec: Dict[str,Any], idx: int, lang: str) -> str:
         if mode: notes.append(("وضع اللعب: " + mode))
         if novr: notes.append("بدون VR: " + novr)
         if vr: notes.append("VR (اختياري): " + vr)
-        if notes: out += ["\n👁‍🗨 ملاحظات:", f"- " + "\n- ".join(notes)]
+        if notes: out += ["\n👁‍🗨 ملاحظات:", f"- " + "\n- ".join(str(x) for x in notes)]
         out.append(f"\nالمستوى التقريبي: {diff}/5")
-        return "\n".join(out)
+        return "\n".join(str(x) for x in out)
     else:
         out = [head, ""]
         if label: out.append(f"🎯 Ideal identity: {label}")
@@ -268,9 +268,9 @@ def render_card(rec: Dict[str,Any], idx: int, lang: str) -> str:
         if mode: notes.append(("Mode: " + mode))
         if novr: notes.append("No-VR: " + novr)
         if vr: notes.append("VR (optional): " + vr)
-        if notes: out += ["\n👁‍🗨 Notes:", f"- " + "\n- ".join(notes)]
+        if notes: out += ["\n👁‍🗨 Notes:", f"- " + "\n- ".join(str(x) for x in notes)]
         out.append(f"\nApprox level: {diff}/5")
-        return "\n".join(out)
+        return "\n".join(str(x) for x in out)
 
 # ---------- نقطة الدخول ----------
 def rank_and_render(answers: Dict[str,Any], lang: str,

--- a/core/shared_utils.py
+++ b/core/shared_utils.py
@@ -49,19 +49,19 @@ def _axes_brief(analysis, lang="العربية"):
             except Exception:
                 pass
             items.append(f"{k}:{v}")
-        return ", ".join(items[:8])
+        return ", ".join(str(x) for x in items[:8])
 
     if lang == "العربية":
         return (
             f"محاور Z (مختصر): {fmt_axes(axes)}\n"
-            + (f"مؤشرات: {', '.join(markers[:6])}\n" if markers else "")
-            + (f"أبرز الدرجات: {', '.join([f'{k}:{scores[k]}' for k in list(scores)[:5]])}\n" if scores else "")
+            + (f"مؤشرات: {', '.join(str(x) for x in markers[:6])}\n" if markers else "")
+            + (f"أبرز الدرجات: {', '.join(str(f'{k}:{scores[k]}') for k in list(scores)[:5])}\n" if scores else "")
         ).strip()
     else:
         return (
             f"Z-axes brief: {fmt_axes(axes)}\n"
-            + (f"Markers: {', '.join(markers[:6])}\n" if markers else "")
-            + (f"Top scores: {', '.join([f'{k}:{scores[k]}' for k in list(scores)[:5]])}\n" if scores else "")
+            + (f"Markers: {', '.join(str(x) for x in markers[:6])}\n" if markers else "")
+            + (f"Top scores: {', '.join(str(f'{k}:{scores[k]}') for k in list(scores)[:5])}\n" if scores else "")
         ).strip()
 
 # =========================================================
@@ -115,10 +115,10 @@ def build_dynamic_personality(analysis, lang="العربية"):
 # [1] برومبت المحادثة الديناميكية (بدون أسماء + بدون مكان/زمن/تكلفة/عدّات)
 # =========================================================
 def build_main_prompt(analysis, answers, personality, previous_recommendation, ratings, lang="العربية"):
-    banned_ar = "، ".join(_BANNED_SPORT_TERMS_AR)
-    banned_en = ", ".join(_BANNED_SPORT_TERMS_EN)
-    avoid = "، ".join(_GENERIC_AVOID)
-    sensory = "، ".join(_SENSORY_TOKENS_AR)
+    banned_ar = "، ".join(str(x) for x in _BANNED_SPORT_TERMS_AR)
+    banned_en = ", ".join(str(x) for x in _BANNED_SPORT_TERMS_EN)
+    avoid = "، ".join(str(x) for x in _GENERIC_AVOID)
+    sensory = "، ".join(str(x) for x in _SENSORY_TOKENS_AR)
     axes_context = _axes_brief(analysis, lang)
 
     if lang == "العربية":
@@ -174,7 +174,7 @@ def build_main_prompt(analysis, answers, personality, previous_recommendation, r
 • علامات تقدّم: ...
 """
     else:
-        avoid_en = ", ".join(_GENERIC_AVOID)
+        avoid_en = ", ".join(str(x) for x in _GENERIC_AVOID)
         prompt = f"""👤 User analysis (brief):
 {analysis.get('quick_profile','fallback')}
 
@@ -232,10 +232,10 @@ Philosophy: {personality.get('philosophy')}
 # [2] برومبت 3 توصيات رئيسية للـ backend (بدون أسماء + بدون مكان/زمن/تكلفة/عدّات)
 # =========================================================
 def generate_main_prompt(analysis, answers, personality, lang="العربية"):
-    banned_ar = "، ".join(_BANNED_SPORT_TERMS_AR)
-    banned_en = ", ".join(_BANNED_SPORT_TERMS_EN)
-    avoid = "، ".join(_GENERIC_AVOID)
-    sensory = "، ".join(_SENSORY_TOKENS_AR)
+    banned_ar = "، ".join(str(x) for x in _BANNED_SPORT_TERMS_AR)
+    banned_en = ", ".join(str(x) for x in _BANNED_SPORT_TERMS_EN)
+    avoid = "، ".join(str(x) for x in _GENERIC_AVOID)
+    sensory = "، ".join(str(x) for x in _SENSORY_TOKENS_AR)
     axes_context = _axes_brief(analysis, lang)
 
     if lang == "العربية":
@@ -292,7 +292,7 @@ def generate_main_prompt(analysis, answers, personality, lang="العربية"):
    • مؤشرات التقدم: ...
 """
     else:
-        avoid_en = ", ".join(_GENERIC_AVOID)
+        avoid_en = ", ".join(str(x) for x in _GENERIC_AVOID)
         prompt = f"""🧠 User analysis (brief): {analysis.get('quick_profile','fallback')}
 {('🧭 ' + axes_context) if axes_context else ''}
 

--- a/core/weekly_batch_engine.py
+++ b/core/weekly_batch_engine.py
@@ -21,7 +21,7 @@ def read_user_sessions():
         return list(reader)
 
 def analyze_user(user):
-    full_text = ' '.join([user.get(f"q{i+1}", "") for i in range(20)]) + ' ' + user.get("custom_input", "")
+    full_text = ' '.join(str(user.get(f"q{i+1}", "")) for i in range(20)) + ' ' + str(user.get("custom_input", ""))
     analysis = {
         "traits_1_40": apply_layers_1_40(full_text),
         "traits_41_80": apply_layers_41_80(full_text),

--- a/quiz_service/app.py
+++ b/quiz_service/app.py
@@ -114,7 +114,7 @@ def typewriter_write(container, text: str, ms_per_char: int = 6):
     buf = []
     for ch in text:
         buf.append(ch)
-        container.markdown("".join(buf))
+        container.markdown("".join(str(x) for x in buf))
         time.sleep(max(ms_per_char, 1) / 1000.0)
 
 def typewriter_chat(role: str, text: str, ms_per_char: int = 6):
@@ -148,12 +148,12 @@ def status_steps(enabled: bool):
             def _init_(self):
                 self.box = st.empty()
                 self.lines = []
-                self.box.write("\n".join(self.lines))
+                self.box.write("\n".join(str(x) for x in self.lines))
             def _enter_(self): return self
             def _exit_(self, *exc): return False
             def write(self, text): 
                 self.lines.append(text)
-                self.box.write("\n".join(self.lines))
+                self.box.write("\n".join(str(x) for x in self.lines))
             def info(self, text): self.write("ℹ " + text)
             def warning(self, text): self.write("⚠ " + text)
             def success(self, text): self.write("✅ " + text)
@@ -277,7 +277,7 @@ if recs:
 
     # تنزيل التوصيات كنص
     if dl and rendered_text:
-        all_text = "\n\n".join(rendered_text)
+        all_text = "\n\n".join(str(x) for x in rendered_text)
         st.download_button(
             label=T("⬇ تنزيل كملف TXT", "⬇ Download as TXT"),
             data=all_text.encode("utf-8"),
@@ -327,8 +327,8 @@ if st.session_state.get("chat_open", False):
                     ):
                         buf.append(chunk)
                         if LIVE_TYPING:
-                            ph.markdown("".join(buf))
-                    reply = "".join(buf).strip()
+                            ph.markdown("".join(str(x) for x in buf))
+                    reply = "".join(str(x) for x in buf).strip()
                 except Exception:
                     reply = T("تم! سنعدّل الخطة بالتدريج حسب ملاحظتك.",
                               "Got it! We’ll adjust the plan gradually based on your feedback.")


### PR DESCRIPTION
## Summary
- sanitize all string joins by coercing elements to `str`
- prevent nested list errors in recommendation and quiz modules

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c8310e22c483218e2822b63e589d26